### PR TITLE
Mobile responsive code updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title></title>
   <style>
     body, html {
@@ -17,11 +18,26 @@
       left: 50%;
       transform: translateX(-50%);
       font-family: monospace;
-      width: 500px;
+      width: 250px;
       text-align: center;
       background: rgba(255, 255, 255, 0.5);
       padding: 20px;
       border-radius: 23px;
+    }
+
+    @media  screen and  (min-width: 600px)  {
+      .timer {
+        width: 500px;
+      }
+    }
+
+    canvas {
+      /* Prevents the scrollbars from showing when using Firefox, Windows 10 */
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
     }
   </style>
 </head>

--- a/index.js
+++ b/index.js
@@ -1,23 +1,30 @@
 const canvas = document.querySelector("canvas");
-const secondsCount = document.querySelector(".seconds")
+const secondsCount = document.querySelector(".seconds");
 const context = canvas.getContext("2d");
 const pugDimensions = { width: 353 * 1.2, height: 325 * 1.2 };
 
-const startTime = Date.now()
+const startTime = Date.now();
 
 canvas.width = window.innerWidth;
 canvas.height = window.innerHeight;
 context.translate(window.innerWidth / 2, window.innerHeight / 2);
 
 const image = new Image();
-image.src = "./assets/pug.png";
+image.src = "./assets/pug.png"; //Photo credit to Matthew Henry (https://unsplash.com/photos/U5rMrSI7Pn4)
 
-const loopingPugs = 40
-const offsetDistance = 100
-let currentOffset = 0
+const loopingPugs = 40; //125 pugs required to cover a full 4K television screen. Tested via Firefox DevTools
+const offsetDistance = 100;
+let currentOffset = 0;
 
 image.onload = () => {
   startLooping();
+};
+
+window.onresize = () => {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  context.setTransform(1, 0, 0, 1, 0, 0); //Reset the canvas context
+  context.translate(window.innerWidth / 2, window.innerHeight / 2);
 };
 
 function draw(offset) {
@@ -30,29 +37,25 @@ function draw(offset) {
   );
 }
 
-
-
 function loopDraw() {
-  for(let i = loopingPugs; i >= 1; i--) {
-    draw(i * offsetDistance + currentOffset)
+  for (let i = loopingPugs; i >= 1; i--) {
+    draw(i * offsetDistance + currentOffset);
   }
 
-  draw(offsetDistance)
+  draw(offsetDistance);
 
-  currentOffset++
-  if(currentOffset >= offsetDistance) {
-    currentOffset = 0
+  currentOffset++;
+  if (currentOffset >= offsetDistance) {
+    currentOffset = 0;
   }
 
-  const newTime = Math.floor((Date.now() - startTime) / 1000)
+  const newTime = Math.floor((Date.now() - startTime) / 1000);
 
-  secondsCount.innerText = newTime
+  secondsCount.innerText = newTime;
 
-  requestAnimationFrame(loopDraw)
+  requestAnimationFrame(loopDraw);
 }
 
 function startLooping() {
-  requestAnimationFrame(loopDraw)
+  requestAnimationFrame(loopDraw);
 }
-
-


### PR DESCRIPTION
The pug in a rug now smoothly resizes when you change your window width.

Additional style rules added to the canvas element to fix current issue with scrollbars showing when using Firefox.

Viewport meta-tag added for good mobile display, timer element shrunk to fit on screen for all mobile devices (resizes to original width for devices >= 600px wide).

Added semi-colons throughout code + photo-credit.