### PR TITLE
Added negative levels

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ const levels = {
 }
 
 const startTime = Date.now();
+let blurStart;
+let totalBlurredTime = 0;
 
 canvas.width = window.innerWidth;
 canvas.height = window.innerHeight;
@@ -101,7 +103,7 @@ function loopDraw() {
     currentOffset = 0;
   }
 
-  const newTime = Math.floor((Date.now() - startTime) / 1000);
+  const newTime = Math.floor((Date.now() - startTime) / 1000) - totalBlurredTime;
 
   secondsCount.innerText = newTime;
 
@@ -111,6 +113,15 @@ function loopDraw() {
 
   requestAnimationFrame(loopDraw);
 }
+
+window.addEventListener('blur', (e) => {
+  blurStart = Date.now();
+})
+
+window.addEventListener('focus', (e) => {
+  let blurredTime = Math.floor((Date.now() - blurStart) / 1000);
+  totalBlurredTime += blurredTime;
+})
 
 function startLooping() {
   requestAnimationFrame(loopDraw);

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const positiveLevels = {
 }
 
 const negativeLevels = {
+  0: "Potential Assistant",
   5: "Minor Failer",
   10: "Amateur Failer",
   15: "Master Failer",
@@ -132,11 +133,19 @@ function loopDraw() {
 
 
   if (newTime > 0) { // if the time is positive, use the positiveLevels
-    console.log('positive')
-    if (positiveLevels[newTime]) {
-    level.innerText = positiveLevels[newTime];
-    }
-  } else { // the time is negative, so use the negativeLevels
+    const levelNumbers = Object.keys(positiveLevels);
+
+    // find the highest level that is less than the current time
+    const currentRank = levelNumbers.reduce((highest, current) => {
+      if (newTime >= current && current > highest) {
+        return parseInt(current)
+      } else { return parseInt(highest) }
+    }, 0);
+    
+    level.innerText = positiveLevels[currentRank];
+
+
+  } else if (newTime < 0) { // the time is negative, so use the negativeLevels
     const levelNumbers = Object.keys(negativeLevels);
 
     // find the highest level that is less than the current time
@@ -148,6 +157,8 @@ function loopDraw() {
     }, 0);
   
     level.innerText = negativeLevels[currentRank];
+  } else { // the time is 0, so use the default level
+    level.innerText = "Assistant";
   }
 
   requestAnimationFrame(loopDraw);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const context = canvas.getContext("2d");
 const pugDimensions = { width: 353 * 1.2, height: 325 * 1.2 };
 
 
-const levels = {
+const positiveLevels = {
+  0: "Assistant",
   5: "Sr Assistant",
   10: "Jr Honoror",
   15: "Master Honoror",
@@ -24,6 +25,28 @@ const levels = {
   10500: "OverLord",
   20500: "King",
   30500: "Anunnaki"
+}
+
+const negativeLevels = {
+  5: "Minor Failer",
+  10: "Amateur Failer",
+  15: "Master Failer",
+  35: "S Tier Failer",
+  65: "Junior Disgrace",
+  105: "Disgrace",
+  150: "Senior Disgrace",
+  250: "Rascal",
+  450: "Pariah",
+  650: "Outcast",
+  1000: "Senior Outcast",
+  1500: "Unemployed",
+  2500: "Beggar",
+  3500: "Criminal",
+  4500: "Wanted Criminal",
+  10500: "Exiled",
+  20500: "Junior Evil Mastermind",
+  30500: "Evil Mastermind",
+  40500: "Senior Partner in the Firm of Evil Mastermind & Sons, Inc.",
 }
 
 const startTime = Date.now();
@@ -107,20 +130,38 @@ function loopDraw() {
 
   secondsCount.innerText = newTime;
 
-  if(levels[newTime]) {
-    level.innerText = levels[newTime]
+
+  if (newTime > 0) { // if the time is positive, use the positiveLevels
+    console.log('positive')
+    if (positiveLevels[newTime]) {
+    level.innerText = positiveLevels[newTime];
+    }
+  } else { // the time is negative, so use the negativeLevels
+    const levelNumbers = Object.keys(negativeLevels);
+
+    // find the highest level that is less than the current time
+    const currentRank = levelNumbers.reduce((highest, current) => {
+      const numOfSeconds = Math.abs(newTime); // convert to positive number
+      if (numOfSeconds >= current && current > highest) {
+        return parseInt(current)
+      } else { return parseInt(highest) }
+    }, 0);
+  
+    level.innerText = negativeLevels[currentRank];
   }
 
   requestAnimationFrame(loopDraw);
 }
 
+// on blur, record the time
 window.addEventListener('blur', (e) => {
   blurStart = Date.now();
 })
 
+// on window focus, record the time spent blurred and add it to the totalBlurredTime
 window.addEventListener('focus', (e) => {
   let blurredTime = Math.floor((Date.now() - blurStart) / 1000);
-  totalBlurredTime += blurredTime;
+  totalBlurredTime += blurredTime * 2; //this has to be doubled to counteract the time that passed while blurred
 })
 
 function startLooping() {


### PR DESCRIPTION
Hey Tim!
Sorry I went radio dark for so long. I took your suggestion in [my last PR](https://github.com/tholman/puginarug/pull/4) and implemented it. I basically just added a event listener on window blur that would start counting down, and eventually go into the negative levels.

Like you suggested, I used my old code for the negative levels, so that it wouldn't be possible to skip a level by not having the window focused. At first I kept the old (intentionally buggy) code for the positive levels, but then I observed that if you got a high rank while active, then the window blurred, when you came back you would still have your high rank, even with a much lower seconds counter. And that didn't seem very honoring to pug 😉. So, I implemented the new code for the positive levels as well.

Let me know if you see any problems, or if there are bugs I missed. This was a lot of fun to work on :)

-James